### PR TITLE
Update list.js 修复预览时，由于路径设置的问题导致的自定义列表无法显示的问题

### DIFF
--- a/_parse/list.js
+++ b/_parse/list.js
@@ -12,7 +12,7 @@ UE.parse.register("list", function(utils) {
     };
 
   utils.extend(this, {
-    liiconpath: "http://bs.baidu.com/listicon/",
+    liiconpath : utils.removeLastbs(this.rootPath) + '/themes/ueditor-list/',
     listDefaultPaddingLeft: "20"
   });
 


### PR DESCRIPTION
修复预览时，由于路径设置的问题导致的自定义列表无法显示的问题。
@liulixingyun