### PR TITLE
修复chrome下scrollTop获取错误导致图片缩放框错位的问题

### DIFF
--- a/_src/plugins/fiximgclick.js
+++ b/_src/plugins/fiximgclick.js
@@ -253,20 +253,21 @@ UE.plugins["fiximgclick"] = (function() {
           iframePos = domUtils.getXY(me.editor.iframe),
           editorPos = domUtils.getXY(resizer.parentNode);
 
+        var doc = me.editor.document;
         domUtils.setStyles(resizer, {
           width: target.width + "px",
           height: target.height + "px",
           left:
             iframePos.x +
               imgPos.x -
-              me.editor.document.body.scrollLeft -
+              (doc.documentElement.scrollLeft || doc.body.scrollLeft || 0) -
               editorPos.x -
               parseInt(resizer.style.borderLeftWidth) +
               "px",
           top:
             iframePos.y +
               imgPos.y -
-              me.editor.document.body.scrollTop -
+              (doc.documentElement.scrollTop || doc.body.scrollTop || 0) -
               editorPos.y -
               parseInt(resizer.style.borderTopWidth) +
               "px"


### PR DESCRIPTION
chrome下，编辑框高度固定时，文章够长出现滚动条时，若滚动条不在最上面，则选择图片时出现的图片缩放框将会错位