### PR TITLE
修复cut操作的撤销栈记录不正确的问题

### DIFF
--- a/_src/plugins/paste.js
+++ b/_src/plugins/paste.js
@@ -314,7 +314,10 @@ UE.plugins["paste"] = function() {
     domUtils.on(me.body, "cut", function() {
       var range = me.selection.getRange();
       if (!range.collapsed && me.undoManger) {
-        me.undoManger.save();
+        if (me.undoManger.list.length < 1) me.undoManger.save();
+        setTimeout(function() {
+          me.undoManger.save();
+        });
       }
     });
 


### PR DESCRIPTION
1.撤销栈为空时直接执行cut操作，应该先一次记录当前的副本，否则无法正确撤销

2.cut操作记录撤销栈时应该save剪切完成后的副本而不是剪切前的（否则会导致cut操作后的内容副本不被记录，如果cut之后立刻执行撤销，看起来会是连续撤销了两步）
@zzkaqq