### PR TITLE
修复远程图片抓取插件默认配置无效的问题

### DIFF
--- a/_src/plugins/catchremoteimage.js
+++ b/_src/plugins/catchremoteimage.js
@@ -10,10 +10,11 @@ UE.plugins["catchremoteimage"] = function() {
     ajax = UE.ajax;
 
   /* 设置默认值 */
-  if (me.options.catchRemoteImageEnable === false) return;
   me.setOpt({
     catchRemoteImageEnable: false
   });
+
+  if (me.options.catchRemoteImageEnable === false) return;
 
   me.addListener("afterpaste", function() {
     me.fireEvent("catchRemoteImage");


### PR DESCRIPTION
参数检测在设置默认参数之后，未配置该项时参数读取为undefined，造成该插件被意外启用