### PR TITLE
修复自动排版配置弹窗中无法设置文字两端对齐的问题

### DIFF
--- a/_src/ui/autotypesetpicker.js
+++ b/_src/ui/autotypesetpicker.js
@@ -72,6 +72,12 @@
         (opt["textAlign"] && opt["textAlign"] == "right" ? "checked" : "") +
         ">" +
         me.getLang("justifyright") +
+        '<input type="radio" name="' +
+        textAlignInputName +
+        '" value="justify" ' +
+        (opt["textAlign"] && opt["textAlign"] == "justify" ? "checked" : "") +
+        ">" +
+        me.getLang("justifyjustify") +
         "</td>" +
         "</tr>" +
         "<tr>" +

--- a/i18n/en/en.js
+++ b/i18n/en/en.js
@@ -206,6 +206,7 @@ UE.I18N['en'] = {
     'justifyleft':'Justify Left',
     'justifyright':'Justify Right',
     'justifycenter':'Justify Center',
+    'justifyjustify':'Default',
     'justify':'Default',
     'clear':'Clear',
     'anchorMsg':'Anchor',

--- a/i18n/ja-jp/ja-jp.js
+++ b/i18n/ja-jp/ja-jp.js
@@ -200,6 +200,7 @@ UE.I18N['ja-jp'] = {
     'justifyleft':'左揃え',
     'justifyright':'右揃え',
     'justifycenter':'中央揃え',
+    'justifyjustify':'両端揃え',
     'justify':'デフォルト',
     'clear':'クリア',
     'anchorMsg':'アンカー',
@@ -556,7 +557,7 @@ UE.I18N['ja-jp'] = {
             'lang_input_target':'新しいウィンドウで開きますか：'
         },
         'validLink':'リンクを選択する場合のみ、有効',
-        'httpPrompt':'ご入力いただいたハイパーリンクにはhttpなどのプロトコル名が含まれておらず、デフォルトはhttp://を追加します' 
+        'httpPrompt':'ご入力いただいたハイパーリンクにはhttpなどのプロトコル名が含まれておらず、デフォルトはhttp://を追加します'
     },
     'map':{
         'static':{

--- a/i18n/zh-cn/zh-cn.js
+++ b/i18n/zh-cn/zh-cn.js
@@ -205,6 +205,7 @@ UE.I18N['zh-cn'] = {
     'justifyleft':'左对齐',
     'justifyright':'右对齐',
     'justifycenter':'居中',
+    'justifyjustify':'两端对齐',
     'justify':'默认',
     'clear':'清除',
     'anchorMsg':'锚点',


### PR DESCRIPTION
自动排版设置中段落的排版方式，可以是 left,right,center,justify四种类型，但点击的弹窗中文字对齐方式只有3个对应的单选框，缺少两端对齐的选项，造成自动排版无法手动修改为两端对齐。该配置对应的语言包中也缺少两端对齐的语言文字，此处也做了相应的补充。